### PR TITLE
Two critical fix bugs: Item duplication in Placer and Breaker breaking unbreakable blocks

### DIFF
--- a/src/main/java/com/khazoda/breakerplacer/block/BreakerBlock.java
+++ b/src/main/java/com/khazoda/breakerplacer/block/BreakerBlock.java
@@ -167,21 +167,18 @@ public class BreakerBlock extends BaseBlock {
    * miningSpeed >= blockHardness ensures the correct tools are used for harder-than-hand-breakable blocks
    **/
   public boolean canBreakBlock(ItemStack stack, CachedBlockPosition cachedPos) {
-    // Get target block's information from cached position
     BlockState blockState = cachedPos.getBlockState();
     BlockPos blockPos = cachedPos.getBlockPos();
     WorldView world = cachedPos.getWorld();
 
-    // Check if the item is a tool and get its mining speed
-    float miningSpeed = stack.getMiningSpeedMultiplier(blockState);
-
-    // Check the block's hardness
     float blockHardness = blockState.getHardness(world, blockPos);
+    
+    if (blockHardness < 0.0F) {
+      return false;
+    }
 
-    // Determine if the tool can break the block
+    float miningSpeed = stack.getMiningSpeedMultiplier(blockState);
     boolean canBreak = miningSpeed > 0.95F && miningSpeed >= blockHardness;
-
-    // Additional check for specific tool materials if needed
     boolean isCorrectTool = stack.isSuitableFor(blockState);
 
     return canBreak || isCorrectTool;

--- a/src/main/java/com/khazoda/breakerplacer/screen/PlacerScreenHandler.java
+++ b/src/main/java/com/khazoda/breakerplacer/screen/PlacerScreenHandler.java
@@ -61,26 +61,5 @@ public class PlacerScreenHandler extends Generic3x3ContainerScreenHandler {
     return this.inventory.canPlayerUse(player);
   }
 
-  @Override
-  public ItemStack quickMove(PlayerEntity player, int invSlot) {
-    ItemStack newStack = ItemStack.EMPTY;
-    Slot slot = this.slots.get(invSlot);
-    if (slot != null && slot.hasStack()) {
-      ItemStack originalStack = slot.getStack();
-      newStack = originalStack.copy();
-      if (invSlot < this.inventory.size()) {
-        if (!this.insertItem(originalStack, this.inventory.size(), this.slots.size(), true)) {
-          return ItemStack.EMPTY;
-        }
-      } else if (!this.insertItem(originalStack, 0, this.inventory.size(), false)) {
-        return ItemStack.EMPTY;
-      }
-      if (originalStack.isEmpty()) {
-        slot.setStack(ItemStack.EMPTY);
-      } else {
-        slot.markDirty();
-      }
-    }
-    return newStack;
-  }
+
 }


### PR DESCRIPTION
## Bug 1: Item duplication in Placer block

**Description:** Shift-clicking items in Placer inventory duplicates them (1→2→4→8→16→32→64)

**Cause:** PlacerScreenHandler incorrectly overrides quickMove() method, causing it to be called on both client and server, each adding items independently.

**Fix:** Remove the quickMove() override from PlacerScreenHandler. The parent class Generic3x3ContainerScreenHandler already provides correct implementation.

**File:** `src/main/java/com/khazoda/breakerplacer/screen/PlacerScreenHandler.java`

**Change:** Delete the entire `quickMove()` method (lines 65-93)

---

## Bug 2: Breaker can break unbreakable blocks

**Description:** Breaker can break bedrock, barriers, command blocks and other unbreakable blocks.

**Cause:** canBreakBlock() doesn't check for blocks with negative hardness.

**Fix:** Add check for `blockHardness < 0.0F` in canBreakBlock() method.

**File:** `src/main/java/com/khazoda/breakerplacer/block/BreakerBlock.java`

**Change:** Add this check after line 177:
```java
if (blockHardness < 0.0F) {
    return false;
}
